### PR TITLE
Fix early golem material registration causing required items to be missing / air

### DIFF
--- a/src/main/java/com/github/voxelfriend/rusticthaumaturgy/core/CommonProxy.java
+++ b/src/main/java/com/github/voxelfriend/rusticthaumaturgy/core/CommonProxy.java
@@ -52,7 +52,6 @@ public class CommonProxy {
 		ModFluidsRT.init();
         ModBlocksRT.init();
         ModItemsRT.init();
-        initGolems();
     }
 	
 	public void init(FMLInitializationEvent event) {
@@ -65,7 +64,7 @@ public class CommonProxy {
                 new ResourceLocation("thaumcraft", "textures/gui/gui_research_back_over.png"));
 		
 		ThaumcraftApi.registerResearchLocation(new ResourceLocation(RusticThaumaturgy.MODID, "research/rustic_thaumaturgy"));
-	
+		initGolems();
 	}
 
     public void postInit(FMLPostInitializationEvent event) {


### PR DESCRIPTION
**EXTREMELY IMPORTANT NOTE**
While this does fix the issue of missing item requirements, it seems Azanor didn't have addons in mind when creating the golem system and made the saved golem materials dependent on registration order. This means that **MERGING THIS MAY CAUSE EXISTING GOLEMS TO CHANGE MATERIALS**. I guess it's up to you whether you want to open this can of worms (eldritch crabs maybe?) or not. 

You currently register the Ironwood golem material in `preInit`, which is before Thaumcraft registers its items (during the registry events that happen between `preInit` and `init`). This means that the items actually passed to the golem material are null. As a result, required items like the simple arcane mechanism are not actually required and replaced with air instead. Moving the registration to `init` is enough to solve the problem.

On a slightly unrelated note, I noticed that your blocks and items are also not registered during the registry events, which is the direction Forge went in 1.12 (and maybe earlier). It's not that big of a deal and I didn't touch them, but I thought I'd let you know.