### PR TITLE
Fixed Rustic 1.1.6+ compatibility

### DIFF
--- a/src/main/java/com/github/voxelfriend/rusticthaumaturgy/crafting/Recipes.java
+++ b/src/main/java/com/github/voxelfriend/rusticthaumaturgy/crafting/Recipes.java
@@ -4,10 +4,6 @@ package com.github.voxelfriend.rusticthaumaturgy.crafting;
 
 //import static blusunrize.immersiveengineering.api.*;
 
-import static rustic.common.crafting.Recipes.brewingRecipes;
-import static rustic.common.crafting.Recipes.crushingTubRecipes;
-import static rustic.common.crafting.Recipes.evaporatingRecipes;
-
 import com.github.voxelfriend.rusticthaumaturgy.common.blocks.ModBlocksRT;
 import com.github.voxelfriend.rusticthaumaturgy.common.blocks.fluids.ModFluidsRT;
 import com.github.voxelfriend.rusticthaumaturgy.common.items.ModItemsRT;
@@ -110,32 +106,32 @@ public class Recipes {
 	
 	public static void addCrushingTubRecipes() {
 		//Cinderfire Wort Crushing Recipes
-		crushingTubRecipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 125), new ItemStack(ModItemsRT.CINDERMOTE)));
-		crushingTubRecipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 250), new ItemStack(BlocksTC.cinderpearl)));
+		rustic.common.crafting.Recipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 125), new ItemStack(ModItemsRT.CINDERMOTE)));
+		rustic.common.crafting.Recipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 250), new ItemStack(BlocksTC.cinderpearl)));
 		
 		//Shimmerdew Wort Crushing Recipes
-		crushingTubRecipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.SHIMMERDEW_WORT, 125), new ItemStack(ModItemsRT.SHIMMERPETAL)));
-		crushingTubRecipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.SHIMMERDEW_WORT, 250), new ItemStack(BlocksTC.shimmerleaf)));
+		rustic.common.crafting.Recipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.SHIMMERDEW_WORT, 125), new ItemStack(ModItemsRT.SHIMMERPETAL)));
+		rustic.common.crafting.Recipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.SHIMMERDEW_WORT, 250), new ItemStack(BlocksTC.shimmerleaf)));
 		
 		//Viscous Brew Crushing Recipes
-		crushingTubRecipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.VISCOUS_WORT, 125), new ItemStack(ModItemsRT.VISCAP)));
-		crushingTubRecipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.VISCOUS_WORT, 250), new ItemStack(BlocksTC.vishroom)));
+		rustic.common.crafting.Recipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.VISCOUS_WORT, 125), new ItemStack(ModItemsRT.VISCAP)));
+		rustic.common.crafting.Recipes.add(new CrushingTubRecipe(new FluidStack(ModFluidsRT.VISCOUS_WORT, 250), new ItemStack(BlocksTC.vishroom)));
 	}
 		
 	public static void addEvaporatingRecipes() {
 		//Tiny Pile of Blaze Powder Evaporation Recipe
-		evaporatingRecipes.add(new EvaporatingBasinRecipe(new ItemStack(ModItemsRT.BLAZE_POWDER_TINY, 1),
+		rustic.common.crafting.Recipes.add(new EvaporatingBasinRecipe(new ItemStack(ModItemsRT.BLAZE_POWDER_TINY, 1),
 					new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 500)));
 	}
 		
 	public static void addBrewingRecipes() {
 		//Cinderfire Whiskey Recipe
-		brewingRecipes.add(new BrewingBarrelRecipe(new FluidStack(ModFluidsRT.CINDERFIRE_WHISKEY, 1), new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 1)));
+		rustic.common.crafting.Recipes.add(new BrewingBarrelRecipe(new FluidStack(ModFluidsRT.CINDERFIRE_WHISKEY, 1), new FluidStack(ModFluidsRT.CINDERFIRE_WORT, 1)));
 		
 		//Shimmerdew Spirits Recipe
-		brewingRecipes.add(new BrewingBarrelRecipe(new FluidStack(ModFluidsRT.SHIMMERDEW_SPIRITS, 1), new FluidStack(ModFluidsRT.SHIMMERDEW_WORT, 1)));
+		rustic.common.crafting.Recipes.add(new BrewingBarrelRecipe(new FluidStack(ModFluidsRT.SHIMMERDEW_SPIRITS, 1), new FluidStack(ModFluidsRT.SHIMMERDEW_WORT, 1)));
 		
 		//Viscous Brew Recipe
-		brewingRecipes.add(new BrewingBarrelRecipe(new FluidStack(ModFluidsRT.VISCOUS_BREW, 1),new FluidStack(ModFluidsRT.VISCOUS_WORT, 1)));
+		rustic.common.crafting.Recipes.add(new BrewingBarrelRecipe(new FluidStack(ModFluidsRT.VISCOUS_BREW, 1),new FluidStack(ModFluidsRT.VISCOUS_WORT, 1)));
 	}
 }


### PR DESCRIPTION
Hi @Voxel-Friend ,

Following my [rustic PR](https://github.com/the-realest-stu/Rustic/pull/298) to improve the evaporating basin, internal changes in Rustic broke Rustic Thaumaturgy.
So I made an API in [rustic PR 299](https://github.com/the-realest-stu/Rustic/pull/299) so that this doesn't happen again.

This PR fixes how Rustic Thaumaturgy adds its rustic recipes by using the provided API instead of directly modifying the data structure. It fixes the crash with rustic 1.1.5+.

*NOTE:* This PR requires that rustic PR 299, above, is merged and released to work
*NOTE:* I did not change the dependencies in build.gradle or wherever they are defined